### PR TITLE
Update mdns_lite and fix warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ def deps do
 end
 ```
 
-Usage:
+## Initial configuration
+
+You need to ensure that mdns is properly set up and configured on your system. On mac mdns is setup by default but on Linux you may need to do some configuration (but the details are not covered in this doc).
+
+For nerves you should follow the mdns_lite instructions: https://hexdocs.pm/mdns_lite/readme.html#dns-bridge-configuration
+
+## Usage
 
 ```elixir
 devices = Keylight.discover()

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,2 +1,1 @@
-use Mix.Config
-
+import Config

--- a/lib/keylight.ex
+++ b/lib/keylight.ex
@@ -3,24 +3,14 @@ defmodule Keylight do
   Documentation for `Keylight`.
   """
 
-  @doc """
-  Hello world.
+  require MdnsLite.DNS
 
-  ## Examples
-
-      iex> Keylight.hello()
-      :world
-
-  """
-
-
-
-  @query_all {:dns_query, '_services._dns-sd._udp.local', :ptr, :in}
-  @query_devices {:dns_query, '_elg._tcp.local', :ptr, :in}
+  @query_devices MdnsLite.DNS.dns_query(class: :in, type: :ptr, domain: '_elg._tcp.local')
   @default_timeout 2000
+
   def discover(timeout \\ @default_timeout) do
     query_mdns()
-    :timer.sleep(@default_timeout)
+    :timer.sleep(timeout)
     case check_mdns() do
       %{additional: []} -> %{}
       %{additional: records} -> records_to_devices(records)

--- a/lib/keylight.ex
+++ b/lib/keylight.ex
@@ -91,7 +91,10 @@ defmodule Keylight do
   end
 
   defp build_url(device, path) do
-    to_charlist("http://#{device.host}:#{device.port}/#{path}")
+    # NOTE: Ideally httpc could do this mapping for us but I'm encountering an
+    # ** error: {:error, {:failed_connect, [{:to_address, {'elgato-key-light-98b1.local', 9123}}, {:inet, [:inet], :nxdomain}]}}
+    {:ok, ip} = MdnsLite.gethostbyname(device.host)
+    ["http://", :inet.ntoa(ip), ":#{device.port}/#{path}"]
   end
 
   defp multi(devices, fun) do

--- a/lib/keylight.ex
+++ b/lib/keylight.ex
@@ -91,10 +91,7 @@ defmodule Keylight do
   end
 
   defp build_url(device, path) do
-    # NOTE: Ideally httpc could do this mapping for us but I'm encountering an
-    # ** error: {:error, {:failed_connect, [{:to_address, {'elgato-key-light-98b1.local', 9123}}, {:inet, [:inet], :nxdomain}]}}
-    {:ok, ip} = MdnsLite.gethostbyname(device.host)
-    ["http://", :inet.ntoa(ip), ":#{device.port}/#{path}"]
+    to_charlist("http://#{device.host}:#{device.port}/#{path}")
   end
 
   defp multi(devices, fun) do

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Keylight.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:mdns_lite, github: "nerves-networking/mdns_lite", branch: "optional-vintage_net"},
+      {:mdns_lite, "~> 0.8.6"},
       {:jason, "~> 1.2"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
-  "mdns_lite": {:git, "https://github.com/nerves-networking/mdns_lite.git", "d0374df15e7b6ca1556ec9d55fad6182b2ccf8ea", [branch: "optional-vintage_net"]},
+  "mdns_lite": {:hex, :mdns_lite, "0.8.6", "cafdcde5be222d151342629637ec3178619090e4668a57c8cfdc67d970d0b268", [:mix], [{:vintage_net, "~> 0.7", [hex: :vintage_net, repo: "hexpm", optional: true]}], "hexpm", "7b6fcf2d45be8823492b77380f69510327d3a98f6b17d403f355daf31e1ac961"},
 }


### PR DESCRIPTION
Updates mdns_lite to latest version and fixes usage of records. Use the record constructor instead of manually constructing the record.

Fix warning about using deprecated `Mix.Config` (`Config` was added in Elixir 1.9 and this project is configured with 1.12 as the minimum)

Remove unused query and actually use the timeout passed to `discover/1`

Uses mdns_lite to lookup the ip address to work around this error I encountered:
> ** (MatchError) no match of right hand side value: {:error, {:failed_connect, [{:to_address, {'elgato-key-light-98b1.local', 9123}}, {:inet, [:inet], :nxdomain}]}}

TODO:
- [x] Fix this error: `MatchError) no match of right hand side value: {:error, {:failed_connect, [{:to_address, {'elgato-key-light-98b1.local', 9123}}, {:inet, [:inet], :nxdomain}]}}`